### PR TITLE
Add support for Azure DevOps wikis

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
       <a href="https://mermaidjs.github.io" target="_blank">Mermaid</a>
       language support to
       <img src="https://github.githubassets.com/favicon.ico" width="16" height="16"/>
-      <a href="https://guides.github.com/features/mastering-markdown/" target="_blank">Github Markdown</a>.
+      <a href="https://guides.github.com/features/mastering-markdown/" target="_blank">Github Markdown</a>
+      and also <a href="https://docs.microsoft.com/en-us/azure/devops/project/wiki/markdown-guidance?view=azure-devops" target="_blank">Azure DevOps</a>.
     </strong>
   </p>
 </div>
@@ -58,6 +59,10 @@
 - [x] Pull requests & issues comment (preview + published)
 - [x] Markdown (`.md`) files (diff + published)
 - [x] Gists - [Demo](https://gist.github.com/amercier/df2e07a994315d323e398120bdda3989)
+
+### Supported Azure DevOps features
+
+- [x] Wikis with code blocks
 
 ### Diagram types
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "GitHub + Mermaid",
   "version": "0.1.1",
   "manifest_version": 2,
-  "description": "A browser extension for Chrome, Opera & Firefox that adds Mermaid language support to GitHub.",
+  "description": "A browser extension for Chrome, Opera & Firefox that adds Mermaid language support to GitHub and Azure DevOps.",
   "icons": {
     "16": "icons/icon-16.png",
     "128": "icons/icon-128.png"
@@ -15,7 +15,8 @@
   },
   "permissions": [
     "https://github.com/*",
-    "https://*.github.com/*"
+    "https://*.github.com/*",
+    "https://dev.azure.com/*"
   ],
   "options_ui": {
     "page": "options.html"
@@ -24,7 +25,8 @@
     {
       "matches": [
         "https://github.com/*",
-        "https://*.github.com/*"
+        "https://*.github.com/*",
+        "https://dev.azure.com/*"
       ],
       "js": [
         "scripts/contentscript.js"

--- a/src/scripts/contentscript.js
+++ b/src/scripts/contentscript.js
@@ -108,13 +108,21 @@ function processElement(source, id) {
 }
 
 /**
- * Process all `pre[lang="mermaid"]` elements that don't have
+ * Process all `pre[lang="mermaid"]` or `pre[class="hljs"]` elements that don't have
  * `[data-processed="true"]`.
  * @param {Iterator<string>} idIterator Id iterator
  */
 function processUnprocessedElements(idIterator) {
   const selector = 'pre[lang="mermaid"]:not([data-processed])';
   [...document.querySelectorAll(selector)].forEach(source => {
+    source.setAttribute('data-processed', 'true')
+    const target = processElement(source, idIterator.next().value)
+  })
+
+  // Azure DevOps Wikis don't provide the language for mermaid, but do provide language
+  // for other known languages such as cpp. We can select code blocks without a language defined
+  const selectorAzure = 'pre[class="hljs"]>code:not([class]):not([data-processed])';
+  [...document.querySelectorAll(selectorAzure)].forEach(source => {
     source.setAttribute('data-processed', 'true')
     const target = processElement(source, idIterator.next().value)
   })


### PR DESCRIPTION
Adds support for Azure DevOps wikis.

Not a lot of changes were required, just adding the URLs to the manifest, and adjusting the selectors.

Azure DevOps seems to put all markdown code blocks into pre[class="hljs"] elements, with a code element under that. Unfortunately they don't expose the language when set to mermaid, but they do expose it for more well-known languages, so I added a selector to exclude any elements where the language is set. This should reduce conflicts with other code block types, but won't fully remove the risk of conflicts.